### PR TITLE
send_sms worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "newrelic": "1.10.3",
     "nodemailer": "0.6.5",
     "sqs-processor": "^1.0.0",
+    "twilio": "^1.11.0",
     "webmaker-postalservice": "0.3.11"
   },
   "devDependencies": {

--- a/processor.js
+++ b/processor.js
@@ -18,7 +18,10 @@ var workers = require("./workers")({
   webmakerURL: process.env.WEBMAKER_URL,
   googleUsername: process.env.GOOGLE_USERNAME,
   googlePassword: process.env.GOOGLE_PASSWORD,
-  mailgunAPIKey: process.env.MAILGUN_API_KEY
+  mailgunAPIKey: process.env.MAILGUN_API_KEY,
+  twilioSid: process.env.TWILIO_SID,
+  twilioAuthToken: process.env.TWILIO_AUTH_TOKEN,
+  twilioFrom: process.env.TWILIO_FROM_NUMBER
 });
 
 queue.startPolling(

--- a/workers/index.js
+++ b/workers/index.js
@@ -22,6 +22,6 @@ module.exports = function(config) {
     badge_awarded_send_email: require("./badge_awarded_send_email")(mailer),
     google_spreadsheet: require("./google_spreadsheet")(config.googleUsername, config.googlePassword),
     hello_world: require("./hello_world"),
-    send_sms: require("./send_sms")
+    send_sms: require("./send_sms")(config.twilioSid, config.twilioAuthToken, config.twilioFrom)
   };
 };

--- a/workers/index.js
+++ b/workers/index.js
@@ -21,6 +21,7 @@ module.exports = function(config) {
     sign_up_for_bsd: require("./sign_up_for_bsd"),
     badge_awarded_send_email: require("./badge_awarded_send_email")(mailer),
     google_spreadsheet: require("./google_spreadsheet")(config.googleUsername, config.googlePassword),
-    hello_world: require("./hello_world")
+    hello_world: require("./hello_world"),
+    send_sms: require("./send_sms")
   };
 };

--- a/workers/send_sms.js
+++ b/workers/send_sms.js
@@ -1,0 +1,21 @@
+var twilio = require("twilio");
+
+var twilioClient = twilio(process.env.TWILIO_SID, process.env.TWILIO_AUTH_TOKEN);
+
+var from = process.env.TWILIO_FROM_NUMBER;
+
+module.exports = function(data, cb) {
+  if ( !data.to || !data.body ) {
+    return cb(new Error("Missing required params for send_sms worker. to: " + !!data.to + ", body: " + !!data.body));
+  }
+
+  twilioClient.messages.create({
+    body: data.body,
+    to: data.to,
+    from: from
+  }).then(function() {
+    cb();
+  }).fail(function(error) {
+    cb(new Error(error.message));
+  });
+};

--- a/workers/send_sms.js
+++ b/workers/send_sms.js
@@ -1,21 +1,33 @@
 var twilio = require("twilio");
 
-var twilioClient = twilio(process.env.TWILIO_SID, process.env.TWILIO_AUTH_TOKEN);
+module.exports = function(sid, authToken, from) {
 
-var from = process.env.TWILIO_FROM_NUMBER;
-
-module.exports = function(data, cb) {
-  if ( !data.to || !data.body ) {
-    return cb(new Error("Missing required params for send_sms worker. to: " + !!data.to + ", body: " + !!data.body));
+  // disable if no config provided
+  if ( !sid && !authToken && !from ) {
+    return function(data, cb) {
+      cb();
+    }
   }
 
-  twilioClient.messages.create({
-    body: data.body,
-    to: data.to,
-    from: from
-  }).then(function() {
-    cb();
-  }).fail(function(error) {
-    cb(new Error(error.message));
-  });
+  var twilioClient = twilio(sid, authToken);
+
+  return function(data, cb) {
+    if ( !data.to ) {
+      return cb(new Error("Missing required `to` param"));
+    }
+
+    if ( !data.body ) {
+      return cb(new Error("Missing required `body` param"));
+    }
+
+    twilioClient.messages.create({
+      body: data.body,
+      to: data.to,
+      from: from
+    })
+    .then(function() {
+      cb();
+    })
+    .fail(cb);
+  };
 };


### PR DESCRIPTION
mozilla/webmaker.org#1258

Uses Twilio to send an SMS to the given phone number.

Adds three env vars:
TWILIO_SID - The SID of the Twilio account
TWILIO_AUTH_TOKEN - The Auth Token for the Twilio account
TWILIO_FROM_NUMBER - The from phone number for the SMS
