### PR TITLE
Check for a livemode flag before sending an email

### DIFF
--- a/workers/mailer.js
+++ b/workers/mailer.js
@@ -20,7 +20,13 @@ module.exports = function (transport) {
     // Automatically generate plain text
     data.generateTextFromHTML = true;
 
-    // Send
-    transport.sendMail(data, cb);
+    // Send if livemode is true, or if no livemode flag is indicated (backwards compatibility for other workers)
+    if (!data.hasOwnProperty('livemode') || data.livemode) {
+      transport.sendMail(data, cb);
+    } else {
+      console.log('Dumping email to console because livemode is disabled');
+      console.log(`To: ${data.to}\nFrom: ${data.from}\nBody: ${data.html}`);
+      cb();
+    }
   };
 };


### PR DESCRIPTION
Staging emails are bouncing, so we're going to head off the problem by dumping staging emails to console rather than sending them. 

Related: mozilla/sawmill#85